### PR TITLE
Fix/suborder invoice pdf button

### DIFF
--- a/dokan-invoice.php
+++ b/dokan-invoice.php
@@ -191,16 +191,9 @@ class Dokan_Invoice {
      * @return array $actions
      */
     public function dokan_invoice_listing_actions_my_account( $actions, $order ) {
-        $order_id     = dokan_get_prop( $order, 'id' );
-        $order_status = dokan_get_prop( $order, 'status' );
-        if ( get_post_meta( $order_id, '_wcpdf_invoice_exists', true ) || in_array( $order_status, apply_filters( 'wpo_wcpdf_myaccount_allowed_order_statuses', array() ) ) ) {
-            $actions[ 'invoice' ] = array(
-                'url'  => wp_nonce_url( admin_url( 'admin-ajax.php?action=generate_wpo_wcpdf&my-account&template_type=invoice&order_ids=' . $order_id ), 'generate_wpo_wcpdf' ),
-                'name' => apply_filters( 'dokan_invoice_myaccount_button_text', __( 'Download invoice (PDF)', 'dokan-invoice' ) )
-            );
-        }
+        $frontend = new \WPO\WC\PDF_Invoices\Frontend();
 
-        return $actions;
+        return $frontend->my_account_pdf_link( $actions, $order );
     }
 
     /**

--- a/dokan-invoice.php
+++ b/dokan-invoice.php
@@ -186,7 +186,7 @@ class Dokan_Invoice {
      * Hooked with WP_invoice filter
      *
      * @param array $actions
-     * @param obj   $order
+     * @param WC_Order $order
      *
      * @return array $actions
      */


### PR DESCRIPTION
Button display logic replaced with `\WPO\WC\PDF_Invoices\Frontend()`

PS: Please set the appropriate Invoice button display settings in *WooCommerce > PDF Invoice> Document > Allow My Account invoice download* Settings

<img width="1242" alt="Screenshot 2021-09-07 at 10 44 15 AM" src="https://user-images.githubusercontent.com/5476784/132285765-16d039d9-68de-4742-bf83-86c29d376e81.png">


fix: https://github.com/weDevsOfficial/dokan-pro/issues/1361